### PR TITLE
Use safer version of mktemp

### DIFF
--- a/c
+++ b/c
@@ -54,7 +54,7 @@ if [ -z "$fname" ]; then
 fi
 
 # create a random biname
-binname=$(mktemp /tmp/c.XXX)
+binname=$(mktemp)
 
 # create stdin file if we need it
 if [ ! -t 0 ]; then


### PR DESCRIPTION
Instead of hardcoded /tmp use $TMPDIR and more XXXs to make it harder to guess name.

Ironically this is done by removing the template option.