### PR TITLE
Use /usr/bin/env instead of absolute path to bash

### DIFF
--- a/c
+++ b/c
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 help_msg() {
     >&$1 echo "Usage: $0 [file.c ... | compiler_options ...] [program arguments]"


### PR DESCRIPTION
On my FreeBSD servers, bash is installed at `/usr/local/bin/bash`, not `/bin/bash`.