### PR TITLE
Fixed use-case of running ./c examples/hello.c

### DIFF
--- a/c
+++ b/c
@@ -78,8 +78,9 @@ fi
 i=0
 for f in ${comp[@]}; do
     if [[ -f "$f" && "$f" != $tmpdir* ]]; then
-        cp "$f" "$tmpdir/$f"
-        comp[$i]="$tmpdir/$f"
+        fbasename=$(basename $f)
+        cp "$f" "$binname.$fbasename"
+        comp[$i]="$binname.$fbasename"
     fi
     let i++
 done


### PR DESCRIPTION
Running ./c examples/hello.c (or any file with a path before it) gives the following error:

    cp: cannot create regular file ‘/tmp/c.jWg/examples/hello.c’: No such file or directory
    cc: error: /tmp/c.jWg/examples/hello.c: No such file or directory
    cc: fatal error: no input files
    compilation terminated.

This commit fixes the issue by taking the temp binary file path and appending the basename of the source file to it.