### PR TITLE
Remove typo in usage

### DIFF
--- a/c
+++ b/c
@@ -5,7 +5,7 @@
 
 help_msg() {
     >&$1 echo "Usage: $0 [file.c ... | compiler_options ...] [program arguments]"
-    >&$1 echo "Execute C progams from the command line."
+    >&$1 echo "Execute C programs from the command line."
     >&$1 echo
     >&$1 echo "  Ex: c main.c"
     >&$1 echo "  Ex: c main.c arg1 arg2"


### PR DESCRIPTION
Hi. I found a small typo ('progams'). Thanks for 'c', it's pretty useful.