### PR TITLE
Removes bug with c library linking with shebang.

### DIFF
--- a/c
+++ b/c
@@ -54,7 +54,8 @@ fi
 for arg in $1; do
     if [[ "$arg" == "--" ]]; then
         fname="$2"
-        comp+=("$2")
+        comp=("$2" "${comp[@]}")
+        # comp+=("$2")
         shift
     else
         comp+=("$arg")

--- a/c
+++ b/c
@@ -55,7 +55,6 @@ for arg in $1; do
     if [[ "$arg" == "--" ]]; then
         fname="$2"
         comp=("$2" "${comp[@]}")
-        # comp+=("$2")
         shift
     else
         comp+=("$arg")


### PR DESCRIPTION
Before when compiling with a shebang like **#!/usr/bin/c -lsomelib --**
it would run as **cc -lsomelib source.c** instead of the proper **cc
source.c -lsomelib**.

 Can't wait to fix all my code generators using the **#!/usr/bin/c -- -lsomelib --** workaround :smile: 