### PR TITLE
Want to have support for running on Solaris and Derivatives like OmniOS

### DIFF
--- a/c
+++ b/c
@@ -23,7 +23,8 @@ cleanup() {
     rm -rf "$tmpdir" "$tmproot/stdin.c"
 
     # remove cache files until we are under $cachesize
-    while [[ "$(du -kc "$tmproot" | tail -1 | cut -f1)" -gt "$C_CACHE_SIZE" ]]; do
+    if [ `uname -s` == "SunOS" ] ; then ducmd="du -ks" ; else ducmd="du -kc" ; fi
+    while [[ "$($ducmd "$tmproot" | tail -1 | cut -f1)" -gt "$C_CACHE_SIZE" ]]; do
         [[ -z "$(ls -A "$tmproot")" ]] && break
         rm -rf "$(find "$tmproot" -type f | tail -n1)"
     done


### PR DESCRIPTION
Thanks for the great handy tool. I quickly realized that only thing not working on Solaris-based systems is the fact that `du` command does not implement `-c`, at least what is normally shipped with the OS does not. In some cases there will be a GNU version, but I think that's fairly atypical. Anyway, perhaps you'll consider this PR, which is enough to make this tool do its thing on Solaris and friends.

Thanks!