### PR TITLE
Updated Homebrew Formula

### DIFF
--- a/c.rb
+++ b/c.rb
@@ -1,7 +1,8 @@
 class C < Formula
   homepage "https://github.com/ryanmjacobs/c"
   url "https://github.com/ryanmjacobs/c/archive/v0.11.tar.gz"
-  sha256 "invalid"
+  sha256 "19b932e0087acf6c639cc5a4fa9a0c87314e62b0561f5517fd7a78e32fb61801"
+  head "https://github.com/ryanmjacobs/c.git"
 
   def install
     bin.install "c"


### PR DESCRIPTION
- Fixed SHA256
- Added head, following `--HEAD` installation

Homebrew Formula requires SHA256 field. I'm not sure about your development platform, but you can use sha256sum command or the following Ruby snippet:

```
require 'digest/sha2'
puts Digest::SHA256.file('v0.11.tar.gz')
```
