### PR TITLE
For users that don't have -Dm for install

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ $ sudo install -Dm 755 c /usr/bin/c
 $ sudo install -Dm 755 c /usr/local/bin/c
 
 # Alternatively, if "-Dm" is not supported by your version of install:
-$ chmod 755 c
-$ sudo install c /path/to/install
+$ sudo install -m 755 c /path/to/install
 ```
 
 For your local user only:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ $ sudo install -Dm 755 c /usr/bin/c
 
 # Or... for systems that prefer /usr/local/bin (e.g. MacOS)
 $ sudo install -Dm 755 c /usr/local/bin/c
+
+# Alternatively, if "-Dm" is not supported by your version of install:
+$ chmod 755 c
+$ sudo install c /path/to/install
 ```
 
 For your local user only:


### PR DESCRIPTION
On Mac High Sierra, it's worth noting that -Dm is not considered as an option for the `install` tool.
I'm not sure about other versions, but I think its worth putting in the extra lines I have to avoid confusion.