### PR TITLE
Cheaper and faster prehash generation mechanism

### DIFF
--- a/c
+++ b/c
@@ -124,10 +124,19 @@ fi
 comp+=("$CPPFLAGS")
 
 # hash all of our data
-prehash="$CC ${comp[@]}" # compiler + flags and files
+prehash=
+argsprehash="$CC"
 for f in "${comp[@]}"; do
-    [ -f "$f" ] && prehash+="$f $(cpp "$f" 2>&1)"
+    if [ -f "$f" ]; then
+        prehash+=$($hash_func < "$f" | cut -d' ' -f1 2>&1)
+    else
+        # Skip any empty args resulting from extra spaces
+        [ "$f" == "" ] && continue
+        argsprehash+="$f"
+    fi
 done
+
+prehash+=$($hash_func <<< "$argsprehash" | cut -d' ' -f1 2>&1)
 
 # hash everything into one unique identifier, for caching purposes
 id="c$("$hash_func" <<< "$prehash" | cut -d' ' -f1)"


### PR DESCRIPTION
I am not sure if you have much interest in this, but I found that this method of creating id is no less reliable and faster as well as cheaper.

I must admit I have not done exhaustive testing, but if you find this interesting I am happy to do a good bit more validation. In my limited testing it has been reliable.

Ran a few comparisons just so there's something I can show. The only difference is this changeset.

These are my two test scripts...
```
#!/bin/sh
echo "*** Run 1000 iterations new method ***"
for i in `seq 0 999`; do
    /home/ubuntu/bin/c.new "redis-h1get.c -ggdb -Wall -I/usr/include/hiredis `pkg-config --libs --cflags hiredis`" h1 tags > /dev/null
done
echo "*** Done running new method ***"
```

```
#!/bin/sh
echo "*** Run 1000 iterations original method ***"
for i in `seq 0 999`; do
    /home/ubuntu/bin/c "redis-h1get.c -ggdb -Wall -I/usr/include/hiredis `pkg-config --libs --cflags hiredis`" h1 tags > /dev/null
done
echo "*** Done original method ***"
```

```
*** Run 1000 iterations new method ***
*** Done running new method ***
3.56user 6.32system 0:38.73elapsed 25%CPU (0avgtext+0avgdata 3280maxresident)k
0inputs+16000outputs (0major+2885064minor)pagefaults 0swaps

*** Run 1000 iterations new method ***
*** Done running new method ***
3.48user 6.51system 0:38.55elapsed 25%CPU (0avgtext+0avgdata 3304maxresident)k
0inputs+16000outputs (0major+2890112minor)pagefaults 0swaps


*** Run 1000 iterations original method ***
*** Done original method ***
17.10user 19.30system 1:02.29elapsed 58%CPU (0avgtext+0avgdata 8440maxresident)k
0inputs+112000outputs (0major+3196581minor)pagefaults 0swaps

*** Run 1000 iterations original method ***
*** Done original method ***
16.76user 20.06system 1:01.91elapsed 59%CPU (0avgtext+0avgdata 8420maxresident)k
0inputs+112000outputs (0major+3196095minor)pagefaults 0swaps
```
Thanks!