### PR TITLE
docs: fix simple typo, tesselation -> tessellation

### DIFF
--- a/examples/dinoshade.c
+++ b/examples/dinoshade.c
@@ -231,7 +231,7 @@ extrudeSolidFromPolygon(GLfloat data[][2], unsigned int dataSize,
 
   if (tobj == NULL) {
     tobj = gluNewTess();  /* create and initialize a GLU
-                             polygon tesselation object */
+                             polygon tessellation object */
     gluTessCallback(tobj, GLU_BEGIN, glBegin);
     gluTessCallback(tobj, GLU_VERTEX, glVertex2fv);  /* semi-tricky */
     gluTessCallback(tobj, GLU_END, glEnd);


### PR DESCRIPTION
There is a small typo in examples/dinoshade.c.

Should read `tessellation` rather than `tesselation`.

