### PR TITLE
Use argv[0] (the first file name) instead of 'c' as the prefix for the cashed binary.

### DIFF
--- a/c
+++ b/c
@@ -153,7 +153,7 @@ for f in "${comp[@]}"; do
 done
 
 # hash everything into one unique identifier, for caching purposes
-id="c$("$hash_func" <<< "$prehash" | cut -d' ' -f1)"
+id="${fname##*/}.hash_$("$hash_func" <<< "$prehash" | cut -d' ' -f1)"
 tmpdir="$tmproot/$id.src"
 binname="$tmproot/$id.bin"
 


### PR DESCRIPTION
Hey there. Here's another change that I made for myself. Feel free to merge if you like it.

The idea is to change the cashed file names for greater recognizably and a chance to auto-complete the file name.

This is useful if one wants to debug, trace, or do something else with the cached file instead of running it, but one does not want to take too much time figuring out which file is the one you want.

For example, the cache directory might currently look like this:

```
/tmp/c.cache.user/c5b2d83aab43bf35b4ecfcf05314f3a95.bin
/tmp/c.cache.user/c612d947ebd92b41dc3e9a8714b11a891.bin
/tmp/c.cache.user/cbe2a1fd1436c5facd83bb12b1bf89baf.bin
```

But with this change, the same directory would look like this:

```
/tmp/c.cache.user/send_email.c.hash_5b2d83aab43bf35b4ecfcf05314f3a95.bin
/tmp/c.cache.user/fetch_news.cpp.hash_612d947ebd92b41dc3e9a8714b11a891.bin
/tmp/c.cache.user/conquer_world.for.hash_be2a1fd1436c5facd83bb12b1bf89baf.bin
```

Sure, then can be multiple cashed binaries for the same file name at the same time, but I feel like this helps in some cases. Modified date helps to disambiguate.

I chose to remove the `c` prefix because, by default, the container folder already indicates that the `c` tool is responsible for these files.

I added the `.hash_` part so that, at quick glance, it can be noted that following string is meant to be a hash and that this is not some sort of file with multiple extensions.

All tests pass.

Have a nice day!